### PR TITLE
Install requires pexpect

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ This allows you to use Pexpect with Serial port which pyserial supports.
 Usage
 -----
 
+```python
     import serial
     from pexpect_serial import SerialSpawn
-    ser = serial.Serial('COM1', 115200)
-    ss = SerialSpawn(ser)
-    ss.sendline('start')
-    ss.expect('done')
+
+    with serial.Serial('COM1', 115200) as ser:
+        ss = SerialSpawn(ser)
+        ss.sendline('start')
+        ss.expect('done')
+```
 
 License
 -------

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
     package_data={
         '': ['README.md', 'LICENSE']
     },
-    packages=find_packages(exclude=('tests', 'docs'))
+    packages=find_packages(exclude=('tests', 'docs')),
+    install_requires=[
+        'pexpect'
+    ],
 )
-


### PR DESCRIPTION
The `pexpect` package is actually required when installing with pip.
_(+ enhance README code layout)_