### PR TITLE
Add Windows support

### DIFF
--- a/pexpect_serial/serial_spawn.py
+++ b/pexpect_serial/serial_spawn.py
@@ -21,7 +21,13 @@ PEXPECT LICENSE
 
 """
 
-from pexpect import spawn
+# pexpect.spawn is not supported on some systems (i.e. Windows(TM))
+# See https://pexpect.readthedocs.io/en/stable/overview.html#pexpect-on-windows for details.
+import os
+if os.name in ['nt']:
+    from pexpect.fdpexpect import fdspawn as spawn
+else:
+    from pexpect import spawn
 from pexpect.exceptions import ExceptionPexpect
 
 __all__ = ['SerialSpawn']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyserial
-pexpect
+pexpect>=4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='pexpect-serial',
-    version='0.1.0',
+    version='0.2.0',
     author='High Wall',
     author_email='hiwall@126.com',
     description='pexpect with pyserial',


### PR DESCRIPTION
This change adds Windows support by using a drop-in class replacement for `pexpect.spawn`, [introduced by pexpect 4.0](https://pexpect.readthedocs.io/en/stable/history.html#version-4-0).